### PR TITLE
Improve mobile layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,20 +18,20 @@
         }
     </style>
 </head>
-<body class="bg-gray-100 text-gray-800 text-sm md:text-base">
-    <div id="app" class="container mx-auto p-1 md:p-4">
-        <h1 class="text-2xl md:text-4xl font-extrabold text-center my-2 md:my-8 text-gray-900">Флеш-карты для обучения</h1>
+<body class="bg-gray-100 text-gray-800 text-xs md:text-sm lg:text-base">
+    <div id="app" class="container mx-auto p-0 md:p-2 lg:p-4">
+        <h1 class="text-base md:text-2xl lg:text-4xl font-extrabold text-center my-1 md:my-3 lg:my-6 text-gray-900">Флеш-карты для обучения</h1>
 
-        <div class="mb-2 md:mb-8">
-            <nav class="flex justify-center space-x-1 md:space-x-4 mb-1 md:mb-4">
-                <button @click="currentView = 'load'" :class="{'bg-green-500 text-white': currentView === 'load', 'bg-blue-500 text-white': currentView !== 'load'}" class="px-2 py-1 rounded-md text-sm font-semibold hover:opacity-90 transition-opacity duration-200">Загрузка колоды</button>
-                <button @click="currentView = 'learn'" :class="{'bg-green-500 text-white': currentView === 'learn', 'bg-blue-500 text-white': currentView !== 'learn'}" class="px-2 py-1 rounded-md text-sm font-semibold hover:opacity-90 transition-opacity duration-200">Изучение</button>
-                <button @click="currentView = 'manage'" :class="{'bg-green-500 text-white': currentView === 'manage', 'bg-blue-500 text-white': currentView !== 'manage'}" class="px-2 py-1 rounded-md text-sm font-semibold hover:opacity-90 transition-opacity duration-200">Управление колодами</button>
+        <div class="mb-0 md:mb-2 lg:mb-4">
+            <nav class="flex justify-center space-x-0 md:space-x-2 lg:space-x-4 mb-0 md:mb-2 lg:mb-4">
+                <button @click="currentView = 'load'" :class="{'bg-green-500 text-white': currentView === 'load', 'bg-blue-500 text-white': currentView !== 'load'}" class="px-1 py-0.5 md:px-2 md:py-1 lg:px-4 lg:py-2 rounded-md text-xs md:text-sm lg:text-base font-semibold hover:opacity-90 transition-opacity duration-200">Загрузка колоды</button>
+                <button @click="currentView = 'learn'" :class="{'bg-green-500 text-white': currentView === 'learn', 'bg-blue-500 text-white': currentView !== 'learn'}" class="px-1 py-0.5 md:px-2 md:py-1 lg:px-4 lg:py-2 rounded-md text-xs md:text-sm lg:text-base font-semibold hover:opacity-90 transition-opacity duration-200">Изучение</button>
+                <button @click="currentView = 'manage'" :class="{'bg-green-500 text-white': currentView === 'manage', 'bg-blue-500 text-white': currentView !== 'manage'}" class="px-1 py-0.5 md:px-2 md:py-1 lg:px-4 lg:py-2 rounded-md text-xs md:text-sm lg:text-base font-semibold hover:opacity-90 transition-opacity duration-200">Управление колодами</button>
             </nav>
         </div>
 
-        <div v-if="currentView === 'load'" class="bg-white p-1 md:p-6 rounded-lg shadow-md">
-            <h2 class="text-xl md:text-3xl font-bold mb-2 md:mb-6 text-gray-800">Загрузка новой колоды</h2>
+        <div v-if="currentView === 'load'" class="bg-white p-0 md:p-2 lg:p-4 rounded-lg shadow-md">
+            <h2 class="text-lg md:text-2xl lg:text-3xl font-bold mb-1 md:mb-2 lg:mb-4 text-gray-800">Загрузка новой колоды</h2>
             <textarea
                 v-model="newDeckInput"
                 class="w-full p-1 md:p-4 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-400 text-sm md:text-lg"
@@ -53,47 +53,47 @@ console.log('Hello, world!');
             <p class="text-sm text-gray-600 mt-2">
                 Используйте `Q.` для вопроса, `A.` для ответа. Разделяйте карточки `---`. Для блоков кода используйте тройные бэктики (\`\`\`).
             </p>
-            <button @click="loadDeck" class="mt-2 md:mt-6 w-full bg-green-600 text-white px-2 py-1 rounded-md text-sm font-semibold hover:bg-green-700 transition-colors duration-200">Загрузить колоду</button>
-            <p v-if="loadMessage" :class="{'text-green-600': loadMessageType === 'success', 'text-red-600': loadMessageType === 'error'}" class="mt-2 text-center text-base md:text-lg">{{ loadMessage }}</p>
+            <button @click="loadDeck" class="mt-1 md:mt-2 lg:mt-4 w-full bg-green-600 text-white px-1 py-0.5 md:px-2 md:py-1 lg:px-4 lg:py-2 rounded-md text-xs md:text-sm lg:text-base font-semibold hover:bg-green-700 transition-colors duration-200">Загрузить колоду</button>
+            <p v-if="loadMessage" :class="{'text-green-600': loadMessageType === 'success', 'text-red-600': loadMessageType === 'error'}" class="mt-1 md:mt-2 lg:mt-4 text-sm md:text-base lg:text-lg">{{ loadMessage }}</p>
         </div>
 
-        <div v-if="currentView === 'learn'" class="bg-white p-1 md:p-8 rounded-lg shadow-md">
-            <h2 class="text-xl md:text-3xl font-bold mb-2 md:mb-6 text-gray-800">Изучение колоды: {{ currentDeck ? currentDeck.name : 'Нет активной колоды' }}</h2>
+        <div v-if="currentView === 'learn'" class="bg-white p-0 md:p-2 lg:p-6 rounded-lg shadow-md">
+            <h2 class="text-lg md:text-2xl lg:text-3xl font-bold mb-1 md:mb-2 lg:mb-4 text-gray-800">Изучение колоды: {{ currentDeck ? currentDeck.name : 'Нет активной колоды' }}</h2>
 
             <div v-if="currentDeck && currentDeck.cards.length > 0">
-                <div v-if="currentCard" class="bg-gray-50 p-2 md:p-6 rounded-lg shadow-inner mb-2 md:mb-6 relative">
+                <div v-if="currentCard" class="bg-gray-50 p-1 md:p-2 lg:p-4 rounded-lg shadow-inner mb-1 md:mb-2 lg:mb-4 relative">
                     <button @click="deleteCurrentCard" class="absolute top-4 right-4 text-gray-400 hover:text-red-500 text-2xl transition-colors duration-200" title="Удалить карточку">
                         🗑️
                     </button>
-                    <p class="text-lg md:text-2xl font-semibold mb-1 md:mb-4 text-gray-900">Q: {{ currentCard.question }}</p>
+                    <p class="text-lg md:text-2xl font-semibold mb-1 md:mb-2 lg:mb-4 text-gray-900">Q: {{ currentCard.question }}</p>
                     <div v-if="showAnswer" class="mt-4 border-t border-gray-200 pt-4">
-                        <p class="text-base md:text-xl font-semibold mb-1 md:mb-2 text-gray-800">A:</p>
+                        <p class="text-sm md:text-base lg:text-xl font-semibold mb-1 md:mb-2 text-gray-800">A:</p>
                         <div v-html="highlightedAnswer" class="prose max-w-none mb-4"></div>
                         <p class="text-sm text-gray-600">Вес карточки: {{ currentCard.weight.toFixed(2) }} | Показов: {{ currentCard.attempts }}</p>
                     </div>
                 </div>
-                <div v-else class="text-center text-gray-600 text-base md:text-xl py-2 md:py-10">
+                <div v-else class="text-center text-gray-600 text-sm md:text-base lg:text-xl py-2 md:py-10">
                     Все карточки в этой колоде изучены или удалены. Выберите другую или загрузите новую.
                 </div>
 
                 <div v-if="currentCard">
-                    <div v-if="!cardRated" class="flex justify-around mt-2 md:mt-6 space-x-2 md:space-x-4">
-                        <button @click="rateCard('forgot')" class="flex-1 bg-red-500 text-white px-2 py-1 rounded-md text-sm font-semibold hover:bg-red-600 transition-colors duration-200">Забыл</button>
-                        <button @click="rateCard('remember')" class="flex-1 bg-yellow-500 text-white px-2 py-1 rounded-md text-sm font-semibold hover:bg-yellow-600 transition-colors duration-200">Припоминаю</button>
-                        <button @click="rateCard('know')" class="flex-1 bg-green-500 text-white px-2 py-1 rounded-md text-sm font-semibold hover:bg-green-600 transition-colors duration-200">Знаю</button>
+                    <div v-if="!cardRated" class="flex justify-around mt-1 md:mt-2 lg:mt-4 space-x-1 md:space-x-2 lg:space-x-4">
+                        <button @click="rateCard('forgot')" class="flex-1 bg-red-500 text-white px-1 py-0.5 md:px-2 md:py-1 lg:px-4 lg:py-2 rounded-md text-xs md:text-sm lg:text-base font-semibold hover:bg-red-600 transition-colors duration-200">Забыл</button>
+                        <button @click="rateCard('remember')" class="flex-1 bg-yellow-500 text-white px-1 py-0.5 md:px-2 md:py-1 lg:px-4 lg:py-2 rounded-md text-xs md:text-sm lg:text-base font-semibold hover:bg-yellow-600 transition-colors duration-200">Припоминаю</button>
+                        <button @click="rateCard('know')" class="flex-1 bg-green-500 text-white px-1 py-0.5 md:px-2 md:py-1 lg:px-4 lg:py-2 rounded-md text-xs md:text-sm lg:text-base font-semibold hover:bg-green-600 transition-colors duration-200">Знаю</button>
                     </div>
-                    <div v-else class="flex justify-center mt-2 md:mt-6 space-x-2 md:space-x-4">
-                        <button @click="getNextCard" class="bg-blue-500 text-white px-3 py-1 rounded-md text-sm font-semibold hover:bg-blue-600 transition-colors duration-200">Следующая карточка</button>
+                    <div v-else class="flex justify-center mt-1 md:mt-2 lg:mt-4 space-x-1 md:space-x-2 lg:space-x-4">
+                        <button @click="getNextCard" class="bg-blue-500 text-white px-1 py-0.5 md:px-2 md:py-1 lg:px-3 lg:py-2 rounded-md text-xs md:text-sm lg:text-base font-semibold hover:bg-blue-600 transition-colors duration-200">Следующая карточка</button>
                     </div>
                 </div>
             </div>
-            <div v-else class="text-center text-gray-600 text-base md:text-xl py-2 md:py-10">
+            <div v-else class="text-center text-gray-600 text-sm md:text-base lg:text-xl py-2 md:py-10">
                 <p>Нет активной колоды или она пуста. Пожалуйста, загрузите колоду на вкладке "Загрузка колоды".</p>
             </div>
         </div>
 
-        <div v-if="currentView === 'manage'" class="bg-white p-1 md:p-8 rounded-lg shadow-md">
-            <h2 class="text-xl md:text-3xl font-bold mb-2 md:mb-6 text-gray-800">Управление колодами</h2>
+        <div v-if="currentView === 'manage'" class="bg-white p-0 md:p-2 lg:p-6 rounded-lg shadow-md">
+            <h2 class="text-lg md:text-2xl lg:text-3xl font-bold mb-1 md:mb-2 lg:mb-4 text-gray-800">Управление колодами</h2>
             <div v-if="decks.length > 0">
                 <ul class="space-y-1 md:space-y-4">
                     <li v-for="deck in decks" :key="deck.id" class="flex flex-col md:flex-row items-start md:items-center justify-between p-1 md:p-5 border border-gray-200 rounded-lg bg-gray-50 shadow-sm">
@@ -103,20 +103,20 @@ console.log('Hello, world!');
                             <p class="text-sm text-gray-500">Карточек: {{ deck.cards.length }}</p>
                         </div>
                         <div class="flex flex-wrap gap-1 md:gap-4 justify-end">
-                            <button @click="loadSavedDeck(deck.id)" class="bg-green-500 text-white px-2 py-1 rounded-md text-sm font-semibold hover:bg-green-600 transition-colors duration-200">Изучить</button>
-                            <button @click="startRenameDeck(deck)" class="bg-blue-500 text-white px-2 py-1 rounded-md text-sm font-semibold hover:bg-blue-600 transition-colors duration-200">Переименовать</button>
-                            <button @click="resetDeckProgress(deck.id)" class="bg-purple-600 text-white px-2 py-1 rounded-md text-sm font-semibold hover:bg-purple-700 transition-colors duration-200">Сбросить прогресс</button>
-                            <button @click="deleteDeck(deck.id)" class="bg-red-500 text-white px-2 py-1 rounded-md text-sm font-semibold hover:bg-red-600 transition-colors duration-200">Удалить</button>
+                            <button @click="loadSavedDeck(deck.id)" class="bg-green-500 text-white px-1 py-0.5 md:px-2 md:py-1 lg:px-4 lg:py-2 rounded-md text-xs md:text-sm lg:text-base font-semibold hover:bg-green-600 transition-colors duration-200">Изучить</button>
+                            <button @click="startRenameDeck(deck)" class="bg-blue-500 text-white px-1 py-0.5 md:px-2 md:py-1 lg:px-4 lg:py-2 rounded-md text-xs md:text-sm lg:text-base font-semibold hover:bg-blue-600 transition-colors duration-200">Переименовать</button>
+                            <button @click="resetDeckProgress(deck.id)" class="bg-purple-600 text-white px-1 py-0.5 md:px-2 md:py-1 lg:px-4 lg:py-2 rounded-md text-xs md:text-sm lg:text-base font-semibold hover:bg-purple-700 transition-colors duration-200">Сбросить прогресс</button>
+                            <button @click="deleteDeck(deck.id)" class="bg-red-500 text-white px-1 py-0.5 md:px-2 md:py-1 lg:px-4 lg:py-2 rounded-md text-xs md:text-sm lg:text-base font-semibold hover:bg-red-600 transition-colors duration-200">Удалить</button>
                         </div>
                     </li>
                 </ul>
             </div>
-            <div v-else class="text-center text-gray-600 text-base md:text-xl py-2 md:py-10">
+            <div v-else class="text-center text-gray-600 text-sm md:text-base lg:text-xl py-2 md:py-10">
                 У вас пока нет сохраненных колод.
             </div>
 
-            <div v-if="isRenaming" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-2 md:p-4">
-                <div class="bg-white p-1 md:p-8 rounded-lg shadow-xl w-full max-w-md">
+            <div v-if="isRenaming" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-1 md:p-2 lg:p-4">
+                <div class="bg-white p-0 md:p-2 lg:p-6 rounded-lg shadow-xl w-full max-w-md">
                     <h3 class="text-lg md:text-2xl font-bold mb-2 md:mb-5 text-gray-800">Переименовать колоду</h3>
                     <input
                         type="text"

--- a/index.html
+++ b/index.html
@@ -8,50 +8,34 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/atom-one-dark.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
     <style>
-        /* Custom styles - minimal, only when Tailwind doesn't suffice */
+        /* Минимальные пользовательские стили */
         body {
             font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
         }
-        pre {
-            /* Basic styling for pre blocks */
-            padding: 1em;
-            border-radius: 0.375rem; /* Equivalent to rounded-lg */
-            overflow-x: auto; /* Allow horizontal scrolling for long lines */
-            background-color: #282c34; /* Matching atom-one-dark theme background */
-        }
-        @media (max-width: 639px) {
-            body {
-                font-size: 0.875rem; /* text-sm */
-            }
-            pre {
-                font-size: 0.75rem;
-                padding: 0.5em;
-            }
-        }
         code {
             font-family: 'Fira Code', 'Cascadia Code', 'Consolas', 'Monaco', 'Andale Mono', 'Ubuntu Mono', monospace;
-            white-space: pre-wrap; /* Ensure long lines wrap */
-            word-break: break-all; /* Break words if necessary */
+            white-space: pre-wrap;
+            word-break: break-all;
         }
     </style>
 </head>
-<body class="bg-gray-100 text-gray-800 text-sm sm:text-base">
-    <div id="app" class="container mx-auto p-2 sm:p-4">
-        <h1 class="text-2xl sm:text-4xl font-extrabold text-center my-4 sm:my-8 text-gray-900">Флеш-карты для обучения</h1>
+<body class="bg-gray-100 text-gray-800 text-sm md:text-base">
+    <div id="app" class="container mx-auto p-2 md:p-4">
+        <h1 class="text-2xl md:text-4xl font-extrabold text-center my-4 md:my-8 text-gray-900">Флеш-карты для обучения</h1>
 
-        <div class="mb-4 sm:mb-8">
-            <nav class="flex justify-center space-x-1 sm:space-x-4 mb-2 sm:mb-4">
+        <div class="mb-4 md:mb-8">
+            <nav class="flex justify-center space-x-1 md:space-x-4 mb-2 md:mb-4">
                 <button @click="currentView = 'load'" :class="{'bg-green-500 text-white': currentView === 'load', 'bg-blue-500 text-white': currentView !== 'load'}" class="px-2 py-1 rounded-md text-sm font-semibold hover:opacity-90 transition-opacity duration-200">Загрузка колоды</button>
                 <button @click="currentView = 'learn'" :class="{'bg-green-500 text-white': currentView === 'learn', 'bg-blue-500 text-white': currentView !== 'learn'}" class="px-2 py-1 rounded-md text-sm font-semibold hover:opacity-90 transition-opacity duration-200">Изучение</button>
                 <button @click="currentView = 'manage'" :class="{'bg-green-500 text-white': currentView === 'manage', 'bg-blue-500 text-white': currentView !== 'manage'}" class="px-2 py-1 rounded-md text-sm font-semibold hover:opacity-90 transition-opacity duration-200">Управление колодами</button>
             </nav>
         </div>
 
-        <div v-if="currentView === 'load'" class="bg-white p-4 sm:p-8 rounded-lg shadow-md">
-            <h2 class="text-xl sm:text-3xl font-bold mb-4 sm:mb-6 text-gray-800">Загрузка новой колоды</h2>
+        <div v-if="currentView === 'load'" class="bg-white p-2 md:p-6 rounded-lg shadow-md">
+            <h2 class="text-xl md:text-3xl font-bold mb-4 md:mb-6 text-gray-800">Загрузка новой колоды</h2>
             <textarea
                 v-model="newDeckInput"
-                class="w-full p-2 sm:p-4 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-400 text-sm sm:text-lg"
+                class="w-full p-2 md:p-4 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-400 text-sm md:text-lg"
                 rows="10"
                 placeholder="Введите карточки в формате:
 Q.
@@ -70,56 +54,56 @@ console.log('Hello, world!');
             <p class="text-sm text-gray-600 mt-2">
                 Используйте `Q.` для вопроса, `A.` для ответа. Разделяйте карточки `---`. Для блоков кода используйте тройные бэктики (\`\`\`).
             </p>
-            <button @click="loadDeck" class="mt-4 sm:mt-6 w-full bg-green-600 text-white px-2 py-1 rounded-md text-sm font-semibold hover:bg-green-700 transition-colors duration-200">Загрузить колоду</button>
-            <p v-if="loadMessage" :class="{'text-green-600': loadMessageType === 'success', 'text-red-600': loadMessageType === 'error'}" class="mt-4 text-center text-base sm:text-lg">{{ loadMessage }}</p>
+            <button @click="loadDeck" class="mt-4 md:mt-6 w-full bg-green-600 text-white px-2 py-1 rounded-md text-sm font-semibold hover:bg-green-700 transition-colors duration-200">Загрузить колоду</button>
+            <p v-if="loadMessage" :class="{'text-green-600': loadMessageType === 'success', 'text-red-600': loadMessageType === 'error'}" class="mt-4 text-center text-base md:text-lg">{{ loadMessage }}</p>
         </div>
 
-        <div v-if="currentView === 'learn'" class="bg-white p-4 sm:p-8 rounded-lg shadow-md">
-            <h2 class="text-xl sm:text-3xl font-bold mb-4 sm:mb-6 text-gray-800">Изучение колоды: {{ currentDeck ? currentDeck.name : 'Нет активной колоды' }}</h2>
+        <div v-if="currentView === 'learn'" class="bg-white p-2 md:p-8 rounded-lg shadow-md">
+            <h2 class="text-xl md:text-3xl font-bold mb-4 md:mb-6 text-gray-800">Изучение колоды: {{ currentDeck ? currentDeck.name : 'Нет активной колоды' }}</h2>
 
             <div v-if="currentDeck && currentDeck.cards.length > 0">
-                <div v-if="currentCard" class="bg-gray-50 p-4 sm:p-6 rounded-lg shadow-inner mb-4 sm:mb-6 relative">
+                <div v-if="currentCard" class="bg-gray-50 p-3 md:p-6 rounded-lg shadow-inner mb-4 md:mb-6 relative">
                     <button @click="deleteCurrentCard" class="absolute top-4 right-4 text-gray-400 hover:text-red-500 text-2xl transition-colors duration-200" title="Удалить карточку">
                         <i class="fas fa-trash-alt"></i>
                     </button>
-                    <p class="text-xl sm:text-2xl font-semibold mb-2 sm:mb-4 text-gray-900">Q: {{ currentCard.question }}</p>
+                    <p class="text-lg md:text-2xl font-semibold mb-2 md:mb-4 text-gray-900">Q: {{ currentCard.question }}</p>
                     <div v-if="showAnswer" class="mt-4 border-t border-gray-200 pt-4">
-                        <p class="text-lg sm:text-xl font-semibold mb-1 sm:mb-2 text-gray-800">A:</p>
+                        <p class="text-base md:text-xl font-semibold mb-1 md:mb-2 text-gray-800">A:</p>
                         <div v-html="highlightedAnswer" class="prose max-w-none mb-4"></div>
                         <p class="text-sm text-gray-600">Вес карточки: {{ currentCard.weight.toFixed(2) }} | Показов: {{ currentCard.attempts }}</p>
                     </div>
                 </div>
-                <div v-else class="text-center text-gray-600 text-lg sm:text-xl py-4 sm:py-10">
+                <div v-else class="text-center text-gray-600 text-base md:text-xl py-4 md:py-10">
                     Все карточки в этой колоде изучены или удалены. Выберите другую или загрузите новую.
                 </div>
 
                 <div v-if="currentCard">
-                    <div v-if="!cardRated" class="flex justify-around mt-4 sm:mt-6 space-x-2 sm:space-x-4">
+                    <div v-if="!cardRated" class="flex justify-around mt-4 md:mt-6 space-x-2 md:space-x-4">
                         <button @click="rateCard('forgot')" class="flex-1 bg-red-500 text-white px-2 py-1 rounded-md text-sm font-semibold hover:bg-red-600 transition-colors duration-200">Забыл</button>
                         <button @click="rateCard('remember')" class="flex-1 bg-yellow-500 text-white px-2 py-1 rounded-md text-sm font-semibold hover:bg-yellow-600 transition-colors duration-200">Припоминаю</button>
                         <button @click="rateCard('know')" class="flex-1 bg-green-500 text-white px-2 py-1 rounded-md text-sm font-semibold hover:bg-green-600 transition-colors duration-200">Знаю</button>
                     </div>
-                    <div v-else class="flex justify-center mt-4 sm:mt-6 space-x-2 sm:space-x-4">
+                    <div v-else class="flex justify-center mt-4 md:mt-6 space-x-2 md:space-x-4">
                         <button @click="getNextCard" class="bg-blue-500 text-white px-3 py-1 rounded-md text-sm font-semibold hover:bg-blue-600 transition-colors duration-200">Следующая карточка</button>
                     </div>
                 </div>
             </div>
-            <div v-else class="text-center text-gray-600 text-lg sm:text-xl py-4 sm:py-10">
+            <div v-else class="text-center text-gray-600 text-base md:text-xl py-4 md:py-10">
                 <p>Нет активной колоды или она пуста. Пожалуйста, загрузите колоду на вкладке "Загрузка колоды".</p>
             </div>
         </div>
 
-        <div v-if="currentView === 'manage'" class="bg-white p-4 sm:p-8 rounded-lg shadow-md">
-            <h2 class="text-xl sm:text-3xl font-bold mb-4 sm:mb-6 text-gray-800">Управление колодами</h2>
+        <div v-if="currentView === 'manage'" class="bg-white p-2 md:p-8 rounded-lg shadow-md">
+            <h2 class="text-xl md:text-3xl font-bold mb-4 md:mb-6 text-gray-800">Управление колодами</h2>
             <div v-if="decks.length > 0">
-                <ul class="space-y-2 sm:space-y-4">
-                    <li v-for="deck in decks" :key="deck.id" class="flex flex-col md:flex-row items-start md:items-center justify-between p-3 sm:p-5 border border-gray-200 rounded-lg bg-gray-50 shadow-sm">
+                <ul class="space-y-2 md:space-y-4">
+                    <li v-for="deck in decks" :key="deck.id" class="flex flex-col md:flex-row items-start md:items-center justify-between p-2 md:p-5 border border-gray-200 rounded-lg bg-gray-50 shadow-sm">
                         <div class="flex-grow mb-2 md:mb-0">
-                            <span class="font-semibold text-lg sm:text-xl text-gray-900">{{ deck.name }}</span>
+                            <span class="font-semibold text-lg md:text-xl text-gray-900">{{ deck.name }}</span>
                             <p class="text-sm text-gray-500 mt-1">Создана: {{ new Date(deck.createdAt).toLocaleString() }}</p>
                             <p class="text-sm text-gray-500">Карточек: {{ deck.cards.length }}</p>
                         </div>
-                        <div class="flex flex-wrap gap-1 sm:gap-4 justify-end">
+                        <div class="flex flex-wrap gap-1 md:gap-4 justify-end">
                             <button @click="loadSavedDeck(deck.id)" class="bg-green-500 text-white px-2 py-1 rounded-md text-sm font-semibold hover:bg-green-600 transition-colors duration-200">Изучить</button>
                             <button @click="startRenameDeck(deck)" class="bg-blue-500 text-white px-2 py-1 rounded-md text-sm font-semibold hover:bg-blue-600 transition-colors duration-200">Переименовать</button>
                             <button @click="resetDeckProgress(deck.id)" class="bg-purple-600 text-white px-2 py-1 rounded-md text-sm font-semibold hover:bg-purple-700 transition-colors duration-200">Сбросить прогресс</button>
@@ -128,18 +112,18 @@ console.log('Hello, world!');
                     </li>
                 </ul>
             </div>
-            <div v-else class="text-center text-gray-600 text-lg sm:text-xl py-4 sm:py-10">
+            <div v-else class="text-center text-gray-600 text-base md:text-xl py-4 md:py-10">
                 У вас пока нет сохраненных колод.
             </div>
 
-            <div v-if="isRenaming" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-2 sm:p-4">
-                <div class="bg-white p-4 sm:p-8 rounded-lg shadow-xl w-full max-w-md">
-                    <h3 class="text-xl sm:text-2xl font-bold mb-3 sm:mb-5 text-gray-800">Переименовать колоду</h3>
+            <div v-if="isRenaming" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-2 md:p-4">
+                <div class="bg-white p-2 md:p-8 rounded-lg shadow-xl w-full max-w-md">
+                    <h3 class="text-lg md:text-2xl font-bold mb-3 md:mb-5 text-gray-800">Переименовать колоду</h3>
                     <input
                         type="text"
                         v-model="newDeckName"
                         @keyup.enter="renameDeck"
-                        class="w-full p-2 sm:p-3 border border-gray-300 rounded-lg mb-2 sm:mb-5 text-sm sm:text-lg focus:outline-none focus:ring-2 focus:ring-blue-400"
+                        class="w-full p-2 md:p-3 border border-gray-300 rounded-lg mb-2 md:mb-5 text-sm md:text-lg focus:outline-none focus:ring-2 focus:ring-blue-400"
                         placeholder="Введите новое название"
                     >
                     <div class="flex justify-end space-x-3">
@@ -180,8 +164,8 @@ console.log('Hello, world!');
                     const codeBlockRegex = /```(\w+)?\n([\s\S]*?)\n```/g;
 
                     processedAnswer = processedAnswer.replace(codeBlockRegex, (match, lang, code) => {
-                        let languageClass = lang ? `language-${lang.toLowerCase()}` : '';
-                        return `<pre><code class="${languageClass}">${code}</code></pre>`;
+                        const languageClass = lang ? `language-${lang.toLowerCase()}` : '';
+                        return `<pre class="p-2 md:p-4 text-xs md:text-sm rounded-lg overflow-auto" style="background-color:#282c34"><code class="${languageClass}">${code}</code></pre>`;
                     });
 
                     const parts = processedAnswer.split(/(<pre[\s\S]*?<\/pre>)/);

--- a/index.html
+++ b/index.html
@@ -27,22 +27,22 @@
     </style>
 </head>
 <body class="bg-gray-100 text-gray-800">
-    <div id="app" class="container mx-auto p-4">
-        <h1 class="text-4xl font-extrabold text-center my-8 text-gray-900">Флеш-карты для обучения</h1>
+    <div id="app" class="container mx-auto p-2 sm:p-4">
+        <h1 class="text-2xl sm:text-4xl font-extrabold text-center my-4 sm:my-8 text-gray-900">Флеш-карты для обучения</h1>
 
         <div class="mb-8">
-            <nav class="flex justify-center space-x-4 mb-4">
-                <button @click="currentView = 'load'" :class="{'bg-green-500 text-white': currentView === 'load', 'bg-blue-500 text-white': currentView !== 'load'}" class="px-6 py-3 rounded-lg text-lg font-semibold hover:opacity-90 transition-opacity duration-200">Загрузка колоды</button>
-                <button @click="currentView = 'learn'" :class="{'bg-green-500 text-white': currentView === 'learn', 'bg-blue-500 text-white': currentView !== 'learn'}" class="px-6 py-3 rounded-lg text-lg font-semibold hover:opacity-90 transition-opacity duration-200">Изучение</button>
-                <button @click="currentView = 'manage'" :class="{'bg-green-500 text-white': currentView === 'manage', 'bg-blue-500 text-white': currentView !== 'manage'}" class="px-6 py-3 rounded-lg text-lg font-semibold hover:opacity-90 transition-opacity duration-200">Управление колодами</button>
+            <nav class="flex justify-center space-x-2 sm:space-x-4 mb-4">
+                <button @click="currentView = 'load'" :class="{'bg-green-500 text-white': currentView === 'load', 'bg-blue-500 text-white': currentView !== 'load'}" class="px-3 py-2 sm:px-6 sm:py-3 rounded-lg text-sm sm:text-lg font-semibold hover:opacity-90 transition-opacity duration-200">Загрузка колоды</button>
+                <button @click="currentView = 'learn'" :class="{'bg-green-500 text-white': currentView === 'learn', 'bg-blue-500 text-white': currentView !== 'learn'}" class="px-3 py-2 sm:px-6 sm:py-3 rounded-lg text-sm sm:text-lg font-semibold hover:opacity-90 transition-opacity duration-200">Изучение</button>
+                <button @click="currentView = 'manage'" :class="{'bg-green-500 text-white': currentView === 'manage', 'bg-blue-500 text-white': currentView !== 'manage'}" class="px-3 py-2 sm:px-6 sm:py-3 rounded-lg text-sm sm:text-lg font-semibold hover:opacity-90 transition-opacity duration-200">Управление колодами</button>
             </nav>
         </div>
 
-        <div v-if="currentView === 'load'" class="bg-white p-8 rounded-lg shadow-md">
-            <h2 class="text-3xl font-bold mb-6 text-gray-800">Загрузка новой колоды</h2>
+        <div v-if="currentView === 'load'" class="bg-white p-4 sm:p-8 rounded-lg shadow-md">
+            <h2 class="text-xl sm:text-3xl font-bold mb-4 sm:mb-6 text-gray-800">Загрузка новой колоды</h2>
             <textarea
                 v-model="newDeckInput"
-                class="w-full p-4 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-400 text-lg"
+                class="w-full p-2 sm:p-4 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-400 text-sm sm:text-lg"
                 rows="10"
                 placeholder="Введите карточки в формате:
 Q.
@@ -61,81 +61,81 @@ console.log('Hello, world!');
             <p class="text-sm text-gray-600 mt-2">
                 Используйте `Q.` для вопроса, `A.` для ответа. Разделяйте карточки `---`. Для блоков кода используйте тройные бэктики (\`\`\`).
             </p>
-            <button @click="loadDeck" class="mt-6 w-full bg-green-600 text-white py-3 rounded-lg text-xl font-bold hover:bg-green-700 transition-colors duration-200">Загрузить колоду</button>
-            <p v-if="loadMessage" :class="{'text-green-600': loadMessageType === 'success', 'text-red-600': loadMessageType === 'error'}" class="mt-4 text-center text-lg">{{ loadMessage }}</p>
+            <button @click="loadDeck" class="mt-4 sm:mt-6 w-full bg-green-600 text-white py-2 sm:py-3 rounded-lg text-lg sm:text-xl font-bold hover:bg-green-700 transition-colors duration-200">Загрузить колоду</button>
+            <p v-if="loadMessage" :class="{'text-green-600': loadMessageType === 'success', 'text-red-600': loadMessageType === 'error'}" class="mt-4 text-center text-base sm:text-lg">{{ loadMessage }}</p>
         </div>
 
-        <div v-if="currentView === 'learn'" class="bg-white p-8 rounded-lg shadow-md">
-            <h2 class="text-3xl font-bold mb-6 text-gray-800">Изучение колоды: {{ currentDeck ? currentDeck.name : 'Нет активной колоды' }}</h2>
+        <div v-if="currentView === 'learn'" class="bg-white p-4 sm:p-8 rounded-lg shadow-md">
+            <h2 class="text-xl sm:text-3xl font-bold mb-4 sm:mb-6 text-gray-800">Изучение колоды: {{ currentDeck ? currentDeck.name : 'Нет активной колоды' }}</h2>
 
             <div v-if="currentDeck && currentDeck.cards.length > 0">
-                <div v-if="currentCard" class="bg-gray-50 p-6 rounded-lg shadow-inner mb-6 relative">
+                <div v-if="currentCard" class="bg-gray-50 p-4 sm:p-6 rounded-lg shadow-inner mb-4 sm:mb-6 relative">
                     <button @click="deleteCurrentCard" class="absolute top-4 right-4 text-gray-400 hover:text-red-500 text-2xl transition-colors duration-200" title="Удалить карточку">
                         <i class="fas fa-trash-alt"></i>
                     </button>
-                    <p class="text-2xl font-semibold mb-4 text-gray-900">Q: {{ currentCard.question }}</p>
+                    <p class="text-xl sm:text-2xl font-semibold mb-2 sm:mb-4 text-gray-900">Q: {{ currentCard.question }}</p>
                     <div v-if="showAnswer" class="mt-4 border-t border-gray-200 pt-4">
-                        <p class="text-xl font-semibold mb-2 text-gray-800">A:</p>
+                        <p class="text-lg sm:text-xl font-semibold mb-1 sm:mb-2 text-gray-800">A:</p>
                         <div v-html="highlightedAnswer" class="prose max-w-none mb-4"></div>
                         <p class="text-sm text-gray-600">Вес карточки: {{ currentCard.weight.toFixed(2) }} | Показов: {{ currentCard.attempts }}</p>
                     </div>
                 </div>
-                <div v-else class="text-center text-gray-600 text-xl py-10">
+                <div v-else class="text-center text-gray-600 text-lg sm:text-xl py-6 sm:py-10">
                     Все карточки в этой колоде изучены или удалены. Выберите другую или загрузите новую.
                 </div>
 
                 <div v-if="currentCard">
-                    <div v-if="!cardRated" class="flex justify-around mt-6 space-x-4">
-                        <button @click="rateCard('forgot')" class="flex-1 bg-red-500 text-white py-3 rounded-lg text-xl font-bold hover:bg-red-600 transition-colors duration-200">Забыл</button>
-                        <button @click="rateCard('remember')" class="flex-1 bg-yellow-500 text-white py-3 rounded-lg text-xl font-bold hover:bg-yellow-600 transition-colors duration-200">Припоминаю</button>
-                        <button @click="rateCard('know')" class="flex-1 bg-green-500 text-white py-3 rounded-lg text-xl font-bold hover:bg-green-600 transition-colors duration-200">Знаю</button>
+                    <div v-if="!cardRated" class="flex justify-around mt-4 sm:mt-6 space-x-2 sm:space-x-4">
+                        <button @click="rateCard('forgot')" class="flex-1 bg-red-500 text-white py-2 sm:py-3 rounded-lg text-lg sm:text-xl font-bold hover:bg-red-600 transition-colors duration-200">Забыл</button>
+                        <button @click="rateCard('remember')" class="flex-1 bg-yellow-500 text-white py-2 sm:py-3 rounded-lg text-lg sm:text-xl font-bold hover:bg-yellow-600 transition-colors duration-200">Припоминаю</button>
+                        <button @click="rateCard('know')" class="flex-1 bg-green-500 text-white py-2 sm:py-3 rounded-lg text-lg sm:text-xl font-bold hover:bg-green-600 transition-colors duration-200">Знаю</button>
                     </div>
-                    <div v-else class="flex justify-center mt-6 space-x-4">
-                        <button @click="getNextCard" class="bg-blue-500 text-white py-3 px-8 rounded-lg text-xl font-bold hover:bg-blue-600 transition-colors duration-200">Следующая карточка</button>
+                    <div v-else class="flex justify-center mt-4 sm:mt-6 space-x-2 sm:space-x-4">
+                        <button @click="getNextCard" class="bg-blue-500 text-white py-2 sm:py-3 px-6 sm:px-8 rounded-lg text-lg sm:text-xl font-bold hover:bg-blue-600 transition-colors duration-200">Следующая карточка</button>
                     </div>
                 </div>
             </div>
-            <div v-else class="text-center text-gray-600 text-xl py-10">
+            <div v-else class="text-center text-gray-600 text-lg sm:text-xl py-6 sm:py-10">
                 <p>Нет активной колоды или она пуста. Пожалуйста, загрузите колоду на вкладке "Загрузка колоды".</p>
             </div>
         </div>
 
-        <div v-if="currentView === 'manage'" class="bg-white p-8 rounded-lg shadow-md">
-            <h2 class="text-3xl font-bold mb-6 text-gray-800">Управление колодами</h2>
+        <div v-if="currentView === 'manage'" class="bg-white p-4 sm:p-8 rounded-lg shadow-md">
+            <h2 class="text-xl sm:text-3xl font-bold mb-4 sm:mb-6 text-gray-800">Управление колодами</h2>
             <div v-if="decks.length > 0">
                 <ul class="space-y-4">
-                    <li v-for="deck in decks" :key="deck.id" class="flex flex-col md:flex-row items-start md:items-center justify-between p-5 border border-gray-200 rounded-lg bg-gray-50 shadow-sm">
+                    <li v-for="deck in decks" :key="deck.id" class="flex flex-col md:flex-row items-start md:items-center justify-between p-3 sm:p-5 border border-gray-200 rounded-lg bg-gray-50 shadow-sm">
                         <div class="flex-grow mb-3 md:mb-0">
-                            <span class="font-semibold text-xl text-gray-900">{{ deck.name }}</span>
+                            <span class="font-semibold text-lg sm:text-xl text-gray-900">{{ deck.name }}</span>
                             <p class="text-sm text-gray-500 mt-1">Создана: {{ new Date(deck.createdAt).toLocaleString() }}</p>
                             <p class="text-sm text-gray-500">Карточек: {{ deck.cards.length }}</p>
                         </div>
-                        <div class="flex flex-wrap gap-2 md:gap-4 justify-end">
-                            <button @click="loadSavedDeck(deck.id)" class="bg-green-500 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-green-600 transition-colors duration-200">Изучить</button>
-                            <button @click="startRenameDeck(deck)" class="bg-blue-500 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-blue-600 transition-colors duration-200">Переименовать</button>
-                            <button @click="resetDeckProgress(deck.id)" class="bg-purple-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-purple-700 transition-colors duration-200">Сбросить прогресс</button>
-                            <button @click="deleteDeck(deck.id)" class="bg-red-500 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-red-600 transition-colors duration-200">Удалить</button>
+                        <div class="flex flex-wrap gap-1 sm:gap-4 justify-end">
+                            <button @click="loadSavedDeck(deck.id)" class="bg-green-500 text-white px-3 sm:px-4 py-1 sm:py-2 rounded-lg text-xs sm:text-sm font-medium hover:bg-green-600 transition-colors duration-200">Изучить</button>
+                            <button @click="startRenameDeck(deck)" class="bg-blue-500 text-white px-3 sm:px-4 py-1 sm:py-2 rounded-lg text-xs sm:text-sm font-medium hover:bg-blue-600 transition-colors duration-200">Переименовать</button>
+                            <button @click="resetDeckProgress(deck.id)" class="bg-purple-600 text-white px-3 sm:px-4 py-1 sm:py-2 rounded-lg text-xs sm:text-sm font-medium hover:bg-purple-700 transition-colors duration-200">Сбросить прогресс</button>
+                            <button @click="deleteDeck(deck.id)" class="bg-red-500 text-white px-3 sm:px-4 py-1 sm:py-2 rounded-lg text-xs sm:text-sm font-medium hover:bg-red-600 transition-colors duration-200">Удалить</button>
                         </div>
                     </li>
                 </ul>
             </div>
-            <div v-else class="text-center text-gray-600 text-xl py-10">
+            <div v-else class="text-center text-gray-600 text-lg sm:text-xl py-6 sm:py-10">
                 У вас пока нет сохраненных колод.
             </div>
 
-            <div v-if="isRenaming" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-                <div class="bg-white p-8 rounded-lg shadow-xl w-full max-w-md">
-                    <h3 class="text-2xl font-bold mb-5 text-gray-800">Переименовать колоду</h3>
+            <div v-if="isRenaming" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-2 sm:p-4">
+                <div class="bg-white p-4 sm:p-8 rounded-lg shadow-xl w-full max-w-md">
+                    <h3 class="text-xl sm:text-2xl font-bold mb-3 sm:mb-5 text-gray-800">Переименовать колоду</h3>
                     <input
                         type="text"
                         v-model="newDeckName"
                         @keyup.enter="renameDeck"
-                        class="w-full p-3 border border-gray-300 rounded-lg mb-5 text-lg focus:outline-none focus:ring-2 focus:ring-blue-400"
+                        class="w-full p-2 sm:p-3 border border-gray-300 rounded-lg mb-3 sm:mb-5 text-sm sm:text-lg focus:outline-none focus:ring-2 focus:ring-blue-400"
                         placeholder="Введите новое название"
                     >
                     <div class="flex justify-end space-x-3">
-                        <button @click="isRenaming = false" class="px-5 py-2 bg-gray-300 rounded-lg text-gray-800 hover:bg-gray-400 transition-colors duration-200">Отмена</button>
-                        <button @click="renameDeck" class="px-5 py-2 bg-green-500 text-white rounded-lg hover:bg-green-600 transition-colors duration-200">Сохранить</button>
+                        <button @click="isRenaming = false" class="px-3 sm:px-5 py-1 sm:py-2 bg-gray-300 rounded-lg text-gray-800 hover:bg-gray-400 transition-colors duration-200">Отмена</button>
+                        <button @click="renameDeck" class="px-3 sm:px-5 py-1 sm:py-2 bg-green-500 text-white rounded-lg hover:bg-green-600 transition-colors duration-200">Сохранить</button>
                     </div>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -67,8 +67,10 @@ console.log('Hello, world!');
                     </button>
                     <p class="text-lg md:text-2xl font-semibold mb-1 md:mb-2 lg:mb-4 text-gray-900">Q: {{ currentCard.question }}</p>
                     <div v-if="showAnswer" class="mt-4 border-t border-gray-200 pt-4">
-                        <p class="text-sm md:text-base lg:text-xl font-semibold mb-1 md:mb-2 text-gray-800">A:</p>
-                        <div v-html="highlightedAnswer" class="prose max-w-none mb-4"></div>
+                        <div class="flex items-start text-lg md:text-2xl font-semibold mb-1 md:mb-2 text-gray-800">
+                            <span class="mr-1">A:</span>
+                            <div v-html="highlightedAnswer" class="prose max-w-none flex-1"></div>
+                        </div>
                         <p class="text-sm text-gray-600">Вес карточки: {{ currentCard.weight.toFixed(2) }} | Показов: {{ currentCard.attempts }}</p>
                     </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -32,9 +32,9 @@
 
         <div class="mb-8">
             <nav class="flex justify-center space-x-2 sm:space-x-4 mb-4">
-                <button @click="currentView = 'load'" :class="{'bg-green-500 text-white': currentView === 'load', 'bg-blue-500 text-white': currentView !== 'load'}" class="px-3 py-2 sm:px-6 sm:py-3 rounded-lg text-sm sm:text-lg font-semibold hover:opacity-90 transition-opacity duration-200">Загрузка колоды</button>
-                <button @click="currentView = 'learn'" :class="{'bg-green-500 text-white': currentView === 'learn', 'bg-blue-500 text-white': currentView !== 'learn'}" class="px-3 py-2 sm:px-6 sm:py-3 rounded-lg text-sm sm:text-lg font-semibold hover:opacity-90 transition-opacity duration-200">Изучение</button>
-                <button @click="currentView = 'manage'" :class="{'bg-green-500 text-white': currentView === 'manage', 'bg-blue-500 text-white': currentView !== 'manage'}" class="px-3 py-2 sm:px-6 sm:py-3 rounded-lg text-sm sm:text-lg font-semibold hover:opacity-90 transition-opacity duration-200">Управление колодами</button>
+                <button @click="currentView = 'load'" :class="{'bg-green-500 text-white': currentView === 'load', 'bg-blue-500 text-white': currentView !== 'load'}" class="px-2 py-1 rounded-md text-sm font-semibold hover:opacity-90 transition-opacity duration-200">Загрузка колоды</button>
+                <button @click="currentView = 'learn'" :class="{'bg-green-500 text-white': currentView === 'learn', 'bg-blue-500 text-white': currentView !== 'learn'}" class="px-2 py-1 rounded-md text-sm font-semibold hover:opacity-90 transition-opacity duration-200">Изучение</button>
+                <button @click="currentView = 'manage'" :class="{'bg-green-500 text-white': currentView === 'manage', 'bg-blue-500 text-white': currentView !== 'manage'}" class="px-2 py-1 rounded-md text-sm font-semibold hover:opacity-90 transition-opacity duration-200">Управление колодами</button>
             </nav>
         </div>
 
@@ -61,7 +61,7 @@ console.log('Hello, world!');
             <p class="text-sm text-gray-600 mt-2">
                 Используйте `Q.` для вопроса, `A.` для ответа. Разделяйте карточки `---`. Для блоков кода используйте тройные бэктики (\`\`\`).
             </p>
-            <button @click="loadDeck" class="mt-4 sm:mt-6 w-full bg-green-600 text-white py-2 sm:py-3 rounded-lg text-lg sm:text-xl font-bold hover:bg-green-700 transition-colors duration-200">Загрузить колоду</button>
+            <button @click="loadDeck" class="mt-4 sm:mt-6 w-full bg-green-600 text-white px-2 py-1 rounded-md text-sm font-semibold hover:bg-green-700 transition-colors duration-200">Загрузить колоду</button>
             <p v-if="loadMessage" :class="{'text-green-600': loadMessageType === 'success', 'text-red-600': loadMessageType === 'error'}" class="mt-4 text-center text-base sm:text-lg">{{ loadMessage }}</p>
         </div>
 
@@ -86,12 +86,12 @@ console.log('Hello, world!');
 
                 <div v-if="currentCard">
                     <div v-if="!cardRated" class="flex justify-around mt-4 sm:mt-6 space-x-2 sm:space-x-4">
-                        <button @click="rateCard('forgot')" class="flex-1 bg-red-500 text-white py-2 sm:py-3 rounded-lg text-lg sm:text-xl font-bold hover:bg-red-600 transition-colors duration-200">Забыл</button>
-                        <button @click="rateCard('remember')" class="flex-1 bg-yellow-500 text-white py-2 sm:py-3 rounded-lg text-lg sm:text-xl font-bold hover:bg-yellow-600 transition-colors duration-200">Припоминаю</button>
-                        <button @click="rateCard('know')" class="flex-1 bg-green-500 text-white py-2 sm:py-3 rounded-lg text-lg sm:text-xl font-bold hover:bg-green-600 transition-colors duration-200">Знаю</button>
+                        <button @click="rateCard('forgot')" class="flex-1 bg-red-500 text-white px-2 py-1 rounded-md text-sm font-semibold hover:bg-red-600 transition-colors duration-200">Забыл</button>
+                        <button @click="rateCard('remember')" class="flex-1 bg-yellow-500 text-white px-2 py-1 rounded-md text-sm font-semibold hover:bg-yellow-600 transition-colors duration-200">Припоминаю</button>
+                        <button @click="rateCard('know')" class="flex-1 bg-green-500 text-white px-2 py-1 rounded-md text-sm font-semibold hover:bg-green-600 transition-colors duration-200">Знаю</button>
                     </div>
                     <div v-else class="flex justify-center mt-4 sm:mt-6 space-x-2 sm:space-x-4">
-                        <button @click="getNextCard" class="bg-blue-500 text-white py-2 sm:py-3 px-6 sm:px-8 rounded-lg text-lg sm:text-xl font-bold hover:bg-blue-600 transition-colors duration-200">Следующая карточка</button>
+                        <button @click="getNextCard" class="bg-blue-500 text-white px-3 py-1 rounded-md text-sm font-semibold hover:bg-blue-600 transition-colors duration-200">Следующая карточка</button>
                     </div>
                 </div>
             </div>
@@ -111,10 +111,10 @@ console.log('Hello, world!');
                             <p class="text-sm text-gray-500">Карточек: {{ deck.cards.length }}</p>
                         </div>
                         <div class="flex flex-wrap gap-1 sm:gap-4 justify-end">
-                            <button @click="loadSavedDeck(deck.id)" class="bg-green-500 text-white px-3 sm:px-4 py-1 sm:py-2 rounded-lg text-xs sm:text-sm font-medium hover:bg-green-600 transition-colors duration-200">Изучить</button>
-                            <button @click="startRenameDeck(deck)" class="bg-blue-500 text-white px-3 sm:px-4 py-1 sm:py-2 rounded-lg text-xs sm:text-sm font-medium hover:bg-blue-600 transition-colors duration-200">Переименовать</button>
-                            <button @click="resetDeckProgress(deck.id)" class="bg-purple-600 text-white px-3 sm:px-4 py-1 sm:py-2 rounded-lg text-xs sm:text-sm font-medium hover:bg-purple-700 transition-colors duration-200">Сбросить прогресс</button>
-                            <button @click="deleteDeck(deck.id)" class="bg-red-500 text-white px-3 sm:px-4 py-1 sm:py-2 rounded-lg text-xs sm:text-sm font-medium hover:bg-red-600 transition-colors duration-200">Удалить</button>
+                            <button @click="loadSavedDeck(deck.id)" class="bg-green-500 text-white px-2 py-1 rounded-md text-sm font-semibold hover:bg-green-600 transition-colors duration-200">Изучить</button>
+                            <button @click="startRenameDeck(deck)" class="bg-blue-500 text-white px-2 py-1 rounded-md text-sm font-semibold hover:bg-blue-600 transition-colors duration-200">Переименовать</button>
+                            <button @click="resetDeckProgress(deck.id)" class="bg-purple-600 text-white px-2 py-1 rounded-md text-sm font-semibold hover:bg-purple-700 transition-colors duration-200">Сбросить прогресс</button>
+                            <button @click="deleteDeck(deck.id)" class="bg-red-500 text-white px-2 py-1 rounded-md text-sm font-semibold hover:bg-red-600 transition-colors duration-200">Удалить</button>
                         </div>
                     </li>
                 </ul>
@@ -134,8 +134,8 @@ console.log('Hello, world!');
                         placeholder="Введите новое название"
                     >
                     <div class="flex justify-end space-x-3">
-                        <button @click="isRenaming = false" class="px-3 sm:px-5 py-1 sm:py-2 bg-gray-300 rounded-lg text-gray-800 hover:bg-gray-400 transition-colors duration-200">Отмена</button>
-                        <button @click="renameDeck" class="px-3 sm:px-5 py-1 sm:py-2 bg-green-500 text-white rounded-lg hover:bg-green-600 transition-colors duration-200">Сохранить</button>
+                        <button @click="isRenaming = false" class="px-2 py-1 bg-gray-300 rounded-md text-sm font-semibold text-gray-800 hover:bg-gray-400 transition-colors duration-200">Отмена</button>
+                        <button @click="renameDeck" class="px-2 py-1 bg-green-500 text-white rounded-md text-sm font-semibold hover:bg-green-600 transition-colors duration-200">Сохранить</button>
                     </div>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -19,6 +19,15 @@
             overflow-x: auto; /* Allow horizontal scrolling for long lines */
             background-color: #282c34; /* Matching atom-one-dark theme background */
         }
+        @media (max-width: 639px) {
+            body {
+                font-size: 0.875rem; /* text-sm */
+            }
+            pre {
+                font-size: 0.75rem;
+                padding: 0.5em;
+            }
+        }
         code {
             font-family: 'Fira Code', 'Cascadia Code', 'Consolas', 'Monaco', 'Andale Mono', 'Ubuntu Mono', monospace;
             white-space: pre-wrap; /* Ensure long lines wrap */
@@ -26,12 +35,12 @@
         }
     </style>
 </head>
-<body class="bg-gray-100 text-gray-800">
+<body class="bg-gray-100 text-gray-800 text-sm sm:text-base">
     <div id="app" class="container mx-auto p-2 sm:p-4">
         <h1 class="text-2xl sm:text-4xl font-extrabold text-center my-4 sm:my-8 text-gray-900">Флеш-карты для обучения</h1>
 
-        <div class="mb-8">
-            <nav class="flex justify-center space-x-2 sm:space-x-4 mb-4">
+        <div class="mb-4 sm:mb-8">
+            <nav class="flex justify-center space-x-1 sm:space-x-4 mb-2 sm:mb-4">
                 <button @click="currentView = 'load'" :class="{'bg-green-500 text-white': currentView === 'load', 'bg-blue-500 text-white': currentView !== 'load'}" class="px-2 py-1 rounded-md text-sm font-semibold hover:opacity-90 transition-opacity duration-200">Загрузка колоды</button>
                 <button @click="currentView = 'learn'" :class="{'bg-green-500 text-white': currentView === 'learn', 'bg-blue-500 text-white': currentView !== 'learn'}" class="px-2 py-1 rounded-md text-sm font-semibold hover:opacity-90 transition-opacity duration-200">Изучение</button>
                 <button @click="currentView = 'manage'" :class="{'bg-green-500 text-white': currentView === 'manage', 'bg-blue-500 text-white': currentView !== 'manage'}" class="px-2 py-1 rounded-md text-sm font-semibold hover:opacity-90 transition-opacity duration-200">Управление колодами</button>
@@ -80,7 +89,7 @@ console.log('Hello, world!');
                         <p class="text-sm text-gray-600">Вес карточки: {{ currentCard.weight.toFixed(2) }} | Показов: {{ currentCard.attempts }}</p>
                     </div>
                 </div>
-                <div v-else class="text-center text-gray-600 text-lg sm:text-xl py-6 sm:py-10">
+                <div v-else class="text-center text-gray-600 text-lg sm:text-xl py-4 sm:py-10">
                     Все карточки в этой колоде изучены или удалены. Выберите другую или загрузите новую.
                 </div>
 
@@ -95,7 +104,7 @@ console.log('Hello, world!');
                     </div>
                 </div>
             </div>
-            <div v-else class="text-center text-gray-600 text-lg sm:text-xl py-6 sm:py-10">
+            <div v-else class="text-center text-gray-600 text-lg sm:text-xl py-4 sm:py-10">
                 <p>Нет активной колоды или она пуста. Пожалуйста, загрузите колоду на вкладке "Загрузка колоды".</p>
             </div>
         </div>
@@ -103,9 +112,9 @@ console.log('Hello, world!');
         <div v-if="currentView === 'manage'" class="bg-white p-4 sm:p-8 rounded-lg shadow-md">
             <h2 class="text-xl sm:text-3xl font-bold mb-4 sm:mb-6 text-gray-800">Управление колодами</h2>
             <div v-if="decks.length > 0">
-                <ul class="space-y-4">
+                <ul class="space-y-2 sm:space-y-4">
                     <li v-for="deck in decks" :key="deck.id" class="flex flex-col md:flex-row items-start md:items-center justify-between p-3 sm:p-5 border border-gray-200 rounded-lg bg-gray-50 shadow-sm">
-                        <div class="flex-grow mb-3 md:mb-0">
+                        <div class="flex-grow mb-2 md:mb-0">
                             <span class="font-semibold text-lg sm:text-xl text-gray-900">{{ deck.name }}</span>
                             <p class="text-sm text-gray-500 mt-1">Создана: {{ new Date(deck.createdAt).toLocaleString() }}</p>
                             <p class="text-sm text-gray-500">Карточек: {{ deck.cards.length }}</p>
@@ -119,7 +128,7 @@ console.log('Hello, world!');
                     </li>
                 </ul>
             </div>
-            <div v-else class="text-center text-gray-600 text-lg sm:text-xl py-6 sm:py-10">
+            <div v-else class="text-center text-gray-600 text-lg sm:text-xl py-4 sm:py-10">
                 У вас пока нет сохраненных колод.
             </div>
 
@@ -130,7 +139,7 @@ console.log('Hello, world!');
                         type="text"
                         v-model="newDeckName"
                         @keyup.enter="renameDeck"
-                        class="w-full p-2 sm:p-3 border border-gray-300 rounded-lg mb-3 sm:mb-5 text-sm sm:text-lg focus:outline-none focus:ring-2 focus:ring-blue-400"
+                        class="w-full p-2 sm:p-3 border border-gray-300 rounded-lg mb-2 sm:mb-5 text-sm sm:text-lg focus:outline-none focus:ring-2 focus:ring-blue-400"
                         placeholder="Введите новое название"
                     >
                     <div class="flex justify-end space-x-3">

--- a/index.html
+++ b/index.html
@@ -6,7 +6,6 @@
     <title>Флеш-карты для обучения</title>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/atom-one-dark.min.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
     <style>
         /* Минимальные пользовательские стили */
         body {
@@ -20,22 +19,22 @@
     </style>
 </head>
 <body class="bg-gray-100 text-gray-800 text-sm md:text-base">
-    <div id="app" class="container mx-auto p-2 md:p-4">
-        <h1 class="text-2xl md:text-4xl font-extrabold text-center my-4 md:my-8 text-gray-900">Флеш-карты для обучения</h1>
+    <div id="app" class="container mx-auto p-1 md:p-4">
+        <h1 class="text-2xl md:text-4xl font-extrabold text-center my-2 md:my-8 text-gray-900">Флеш-карты для обучения</h1>
 
-        <div class="mb-4 md:mb-8">
-            <nav class="flex justify-center space-x-1 md:space-x-4 mb-2 md:mb-4">
+        <div class="mb-2 md:mb-8">
+            <nav class="flex justify-center space-x-1 md:space-x-4 mb-1 md:mb-4">
                 <button @click="currentView = 'load'" :class="{'bg-green-500 text-white': currentView === 'load', 'bg-blue-500 text-white': currentView !== 'load'}" class="px-2 py-1 rounded-md text-sm font-semibold hover:opacity-90 transition-opacity duration-200">Загрузка колоды</button>
                 <button @click="currentView = 'learn'" :class="{'bg-green-500 text-white': currentView === 'learn', 'bg-blue-500 text-white': currentView !== 'learn'}" class="px-2 py-1 rounded-md text-sm font-semibold hover:opacity-90 transition-opacity duration-200">Изучение</button>
                 <button @click="currentView = 'manage'" :class="{'bg-green-500 text-white': currentView === 'manage', 'bg-blue-500 text-white': currentView !== 'manage'}" class="px-2 py-1 rounded-md text-sm font-semibold hover:opacity-90 transition-opacity duration-200">Управление колодами</button>
             </nav>
         </div>
 
-        <div v-if="currentView === 'load'" class="bg-white p-2 md:p-6 rounded-lg shadow-md">
-            <h2 class="text-xl md:text-3xl font-bold mb-4 md:mb-6 text-gray-800">Загрузка новой колоды</h2>
+        <div v-if="currentView === 'load'" class="bg-white p-1 md:p-6 rounded-lg shadow-md">
+            <h2 class="text-xl md:text-3xl font-bold mb-2 md:mb-6 text-gray-800">Загрузка новой колоды</h2>
             <textarea
                 v-model="newDeckInput"
-                class="w-full p-2 md:p-4 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-400 text-sm md:text-lg"
+                class="w-full p-1 md:p-4 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-400 text-sm md:text-lg"
                 rows="10"
                 placeholder="Введите карточки в формате:
 Q.
@@ -54,51 +53,51 @@ console.log('Hello, world!');
             <p class="text-sm text-gray-600 mt-2">
                 Используйте `Q.` для вопроса, `A.` для ответа. Разделяйте карточки `---`. Для блоков кода используйте тройные бэктики (\`\`\`).
             </p>
-            <button @click="loadDeck" class="mt-4 md:mt-6 w-full bg-green-600 text-white px-2 py-1 rounded-md text-sm font-semibold hover:bg-green-700 transition-colors duration-200">Загрузить колоду</button>
-            <p v-if="loadMessage" :class="{'text-green-600': loadMessageType === 'success', 'text-red-600': loadMessageType === 'error'}" class="mt-4 text-center text-base md:text-lg">{{ loadMessage }}</p>
+            <button @click="loadDeck" class="mt-2 md:mt-6 w-full bg-green-600 text-white px-2 py-1 rounded-md text-sm font-semibold hover:bg-green-700 transition-colors duration-200">Загрузить колоду</button>
+            <p v-if="loadMessage" :class="{'text-green-600': loadMessageType === 'success', 'text-red-600': loadMessageType === 'error'}" class="mt-2 text-center text-base md:text-lg">{{ loadMessage }}</p>
         </div>
 
-        <div v-if="currentView === 'learn'" class="bg-white p-2 md:p-8 rounded-lg shadow-md">
-            <h2 class="text-xl md:text-3xl font-bold mb-4 md:mb-6 text-gray-800">Изучение колоды: {{ currentDeck ? currentDeck.name : 'Нет активной колоды' }}</h2>
+        <div v-if="currentView === 'learn'" class="bg-white p-1 md:p-8 rounded-lg shadow-md">
+            <h2 class="text-xl md:text-3xl font-bold mb-2 md:mb-6 text-gray-800">Изучение колоды: {{ currentDeck ? currentDeck.name : 'Нет активной колоды' }}</h2>
 
             <div v-if="currentDeck && currentDeck.cards.length > 0">
-                <div v-if="currentCard" class="bg-gray-50 p-3 md:p-6 rounded-lg shadow-inner mb-4 md:mb-6 relative">
+                <div v-if="currentCard" class="bg-gray-50 p-2 md:p-6 rounded-lg shadow-inner mb-2 md:mb-6 relative">
                     <button @click="deleteCurrentCard" class="absolute top-4 right-4 text-gray-400 hover:text-red-500 text-2xl transition-colors duration-200" title="Удалить карточку">
-                        <i class="fas fa-trash-alt"></i>
+                        🗑️
                     </button>
-                    <p class="text-lg md:text-2xl font-semibold mb-2 md:mb-4 text-gray-900">Q: {{ currentCard.question }}</p>
+                    <p class="text-lg md:text-2xl font-semibold mb-1 md:mb-4 text-gray-900">Q: {{ currentCard.question }}</p>
                     <div v-if="showAnswer" class="mt-4 border-t border-gray-200 pt-4">
                         <p class="text-base md:text-xl font-semibold mb-1 md:mb-2 text-gray-800">A:</p>
                         <div v-html="highlightedAnswer" class="prose max-w-none mb-4"></div>
                         <p class="text-sm text-gray-600">Вес карточки: {{ currentCard.weight.toFixed(2) }} | Показов: {{ currentCard.attempts }}</p>
                     </div>
                 </div>
-                <div v-else class="text-center text-gray-600 text-base md:text-xl py-4 md:py-10">
+                <div v-else class="text-center text-gray-600 text-base md:text-xl py-2 md:py-10">
                     Все карточки в этой колоде изучены или удалены. Выберите другую или загрузите новую.
                 </div>
 
                 <div v-if="currentCard">
-                    <div v-if="!cardRated" class="flex justify-around mt-4 md:mt-6 space-x-2 md:space-x-4">
+                    <div v-if="!cardRated" class="flex justify-around mt-2 md:mt-6 space-x-2 md:space-x-4">
                         <button @click="rateCard('forgot')" class="flex-1 bg-red-500 text-white px-2 py-1 rounded-md text-sm font-semibold hover:bg-red-600 transition-colors duration-200">Забыл</button>
                         <button @click="rateCard('remember')" class="flex-1 bg-yellow-500 text-white px-2 py-1 rounded-md text-sm font-semibold hover:bg-yellow-600 transition-colors duration-200">Припоминаю</button>
                         <button @click="rateCard('know')" class="flex-1 bg-green-500 text-white px-2 py-1 rounded-md text-sm font-semibold hover:bg-green-600 transition-colors duration-200">Знаю</button>
                     </div>
-                    <div v-else class="flex justify-center mt-4 md:mt-6 space-x-2 md:space-x-4">
+                    <div v-else class="flex justify-center mt-2 md:mt-6 space-x-2 md:space-x-4">
                         <button @click="getNextCard" class="bg-blue-500 text-white px-3 py-1 rounded-md text-sm font-semibold hover:bg-blue-600 transition-colors duration-200">Следующая карточка</button>
                     </div>
                 </div>
             </div>
-            <div v-else class="text-center text-gray-600 text-base md:text-xl py-4 md:py-10">
+            <div v-else class="text-center text-gray-600 text-base md:text-xl py-2 md:py-10">
                 <p>Нет активной колоды или она пуста. Пожалуйста, загрузите колоду на вкладке "Загрузка колоды".</p>
             </div>
         </div>
 
-        <div v-if="currentView === 'manage'" class="bg-white p-2 md:p-8 rounded-lg shadow-md">
-            <h2 class="text-xl md:text-3xl font-bold mb-4 md:mb-6 text-gray-800">Управление колодами</h2>
+        <div v-if="currentView === 'manage'" class="bg-white p-1 md:p-8 rounded-lg shadow-md">
+            <h2 class="text-xl md:text-3xl font-bold mb-2 md:mb-6 text-gray-800">Управление колодами</h2>
             <div v-if="decks.length > 0">
-                <ul class="space-y-2 md:space-y-4">
-                    <li v-for="deck in decks" :key="deck.id" class="flex flex-col md:flex-row items-start md:items-center justify-between p-2 md:p-5 border border-gray-200 rounded-lg bg-gray-50 shadow-sm">
-                        <div class="flex-grow mb-2 md:mb-0">
+                <ul class="space-y-1 md:space-y-4">
+                    <li v-for="deck in decks" :key="deck.id" class="flex flex-col md:flex-row items-start md:items-center justify-between p-1 md:p-5 border border-gray-200 rounded-lg bg-gray-50 shadow-sm">
+                        <div class="flex-grow mb-1 md:mb-0">
                             <span class="font-semibold text-lg md:text-xl text-gray-900">{{ deck.name }}</span>
                             <p class="text-sm text-gray-500 mt-1">Создана: {{ new Date(deck.createdAt).toLocaleString() }}</p>
                             <p class="text-sm text-gray-500">Карточек: {{ deck.cards.length }}</p>
@@ -112,18 +111,18 @@ console.log('Hello, world!');
                     </li>
                 </ul>
             </div>
-            <div v-else class="text-center text-gray-600 text-base md:text-xl py-4 md:py-10">
+            <div v-else class="text-center text-gray-600 text-base md:text-xl py-2 md:py-10">
                 У вас пока нет сохраненных колод.
             </div>
 
             <div v-if="isRenaming" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-2 md:p-4">
-                <div class="bg-white p-2 md:p-8 rounded-lg shadow-xl w-full max-w-md">
-                    <h3 class="text-lg md:text-2xl font-bold mb-3 md:mb-5 text-gray-800">Переименовать колоду</h3>
+                <div class="bg-white p-1 md:p-8 rounded-lg shadow-xl w-full max-w-md">
+                    <h3 class="text-lg md:text-2xl font-bold mb-2 md:mb-5 text-gray-800">Переименовать колоду</h3>
                     <input
                         type="text"
                         v-model="newDeckName"
                         @keyup.enter="renameDeck"
-                        class="w-full p-2 md:p-3 border border-gray-300 rounded-lg mb-2 md:mb-5 text-sm md:text-lg focus:outline-none focus:ring-2 focus:ring-blue-400"
+                        class="w-full p-1 md:p-3 border border-gray-300 rounded-lg mb-2 md:mb-5 text-sm md:text-lg focus:outline-none focus:ring-2 focus:ring-blue-400"
                         placeholder="Введите новое название"
                     >
                     <div class="flex justify-end space-x-3">


### PR DESCRIPTION
## Summary
- tune container spacing and heading sizes
- adjust button sizes and paddings for small screens
- reduce paddings in manage deck interface
- make rename dialog mobile-friendly

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_6852f139d4608325907ab703c0841964